### PR TITLE
Agregar prototipo iOS 'PlacesMemory' en SwiftUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
-# python
-Repositorio para ejercicios con python
+# PlacesMemory
+
+Prototipo de app iOS para guardar lugares de interés mientras caminas por una ciudad. La idea es poder abrir la app, capturar la ubicación actual, añadir una nota y encontrar ese punto más adelante en una lista o en Apple Maps.
+
+## Funcionalidades incluidas
+
+- Guardar un lugar con nombre, categoría, nota y coordenadas GPS actuales.
+- Solicitar permiso de ubicación solo cuando se necesita capturar un punto.
+- Persistir los lugares localmente en un archivo JSON dentro del directorio de documentos de la app.
+- Ver los lugares guardados en una lista cronológica.
+- Abrir el detalle de un lugar con mapa, nota, categoría y botón para navegar en Apple Maps.
+- Eliminar lugares desde la lista.
+
+## Estructura
+
+```text
+ios/PlacesMemory/
+├── project.yml                  # Configuración para generar el proyecto Xcode con XcodeGen
+└── PlacesMemory/
+    ├── Info.plist
+    ├── PlacesMemoryApp.swift
+    ├── Models/Place.swift
+    ├── Services/LocationManager.swift
+    ├── Services/PlacesStore.swift
+    └── Views/
+        ├── AddPlaceView.swift
+        ├── PlaceDetailView.swift
+        └── PlacesListView.swift
+```
+
+## Cómo abrirlo en Xcode
+
+Este repositorio incluye un `project.yml` para generar el proyecto con [XcodeGen](https://github.com/yonaskolb/XcodeGen):
+
+```bash
+cd ios/PlacesMemory
+xcodegen generate
+open PlacesMemory.xcodeproj
+```
+
+Después, selecciona un simulador o un iPhone físico y ejecuta la app desde Xcode. Para probar la captura real de coordenadas es recomendable usar un dispositivo físico o configurar una ubicación simulada en el simulador.
+
+## Próximos pasos recomendados
+
+- Añadir búsqueda y filtros por categoría.
+- Permitir adjuntar fotos a cada lugar.
+- Añadir etiquetas personalizadas.
+- Sincronizar con iCloud para conservar lugares entre dispositivos.
+- Crear recordatorios o rutas de visita por cercanía.

--- a/ios/PlacesMemory/PlacesMemory/Info.plist
+++ b/ios/PlacesMemory/PlacesMemory/Info.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>PlacesMemory</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Usamos tu ubicación solo cuando guardas un lugar de interés cercano.</string>
+	<key>UILaunchScreen</key>
+	<dict/>
+</dict>
+</plist>

--- a/ios/PlacesMemory/PlacesMemory/Models/Place.swift
+++ b/ios/PlacesMemory/PlacesMemory/Models/Place.swift
@@ -1,0 +1,62 @@
+import Foundation
+import CoreLocation
+
+struct Place: Identifiable, Codable, Equatable {
+    var id: UUID
+    var title: String
+    var category: PlaceCategory
+    var note: String
+    var latitude: Double
+    var longitude: Double
+    var createdAt: Date
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        category: PlaceCategory,
+        note: String,
+        latitude: Double,
+        longitude: Double,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.title = title
+        self.category = category
+        self.note = note
+        self.latitude = latitude
+        self.longitude = longitude
+        self.createdAt = createdAt
+    }
+
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+}
+
+enum PlaceCategory: String, CaseIterable, Codable, Identifiable {
+    case cafe = "Café"
+    case restaurant = "Restaurante"
+    case shop = "Tienda"
+    case viewpoint = "Mirador"
+    case culture = "Cultura"
+    case other = "Otro"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .cafe:
+            return "cup.and.saucer.fill"
+        case .restaurant:
+            return "fork.knife"
+        case .shop:
+            return "bag.fill"
+        case .viewpoint:
+            return "binoculars.fill"
+        case .culture:
+            return "theatermasks.fill"
+        case .other:
+            return "mappin.circle.fill"
+        }
+    }
+}

--- a/ios/PlacesMemory/PlacesMemory/PlacesMemoryApp.swift
+++ b/ios/PlacesMemory/PlacesMemory/PlacesMemoryApp.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+@main
+struct PlacesMemoryApp: App {
+    @StateObject private var store = PlacesStore()
+    @StateObject private var locationManager = LocationManager()
+
+    var body: some Scene {
+        WindowGroup {
+            PlacesListView()
+                .environmentObject(store)
+                .environmentObject(locationManager)
+        }
+    }
+}

--- a/ios/PlacesMemory/PlacesMemory/Services/LocationManager.swift
+++ b/ios/PlacesMemory/PlacesMemory/Services/LocationManager.swift
@@ -1,0 +1,57 @@
+import Combine
+import CoreLocation
+import Foundation
+
+@MainActor
+final class LocationManager: NSObject, ObservableObject {
+    @Published var currentLocation: CLLocation?
+    @Published var authorizationStatus: CLAuthorizationStatus
+    @Published var errorMessage: String?
+
+    private let manager = CLLocationManager()
+
+    override init() {
+        authorizationStatus = manager.authorizationStatus
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyBest
+    }
+
+    func requestCurrentLocation() {
+        errorMessage = nil
+
+        switch manager.authorizationStatus {
+        case .notDetermined:
+            manager.requestWhenInUseAuthorization()
+        case .authorizedAlways, .authorizedWhenInUse:
+            manager.requestLocation()
+        case .denied, .restricted:
+            errorMessage = "Activa el permiso de ubicación en Ajustes para guardar el punto exacto."
+        @unknown default:
+            errorMessage = "No se pudo comprobar el permiso de ubicación."
+        }
+    }
+}
+
+extension LocationManager: CLLocationManagerDelegate {
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        Task { @MainActor in
+            self.authorizationStatus = manager.authorizationStatus
+            if self.authorizationStatus == .authorizedWhenInUse || self.authorizationStatus == .authorizedAlways {
+                manager.requestLocation()
+            }
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        Task { @MainActor in
+            self.currentLocation = locations.last
+        }
+    }
+
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        Task { @MainActor in
+            self.errorMessage = "No se pudo obtener la ubicación actual. Inténtalo de nuevo."
+        }
+    }
+}

--- a/ios/PlacesMemory/PlacesMemory/Services/PlacesStore.swift
+++ b/ios/PlacesMemory/PlacesMemory/Services/PlacesStore.swift
@@ -1,0 +1,48 @@
+import Combine
+import Foundation
+
+@MainActor
+final class PlacesStore: ObservableObject {
+    @Published private(set) var places: [Place] = []
+
+    private let fileManager: FileManager
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+        load()
+    }
+
+    func add(_ place: Place) {
+        places.insert(place, at: 0)
+        save()
+    }
+
+    func delete(at offsets: IndexSet) {
+        places.remove(atOffsets: offsets)
+        save()
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: storageURL) else {
+            places = []
+            return
+        }
+
+        places = (try? decoder.decode([Place].self, from: data)) ?? []
+    }
+
+    private func save() {
+        guard let data = try? encoder.encode(places) else { return }
+        try? data.write(to: storageURL, options: [.atomic])
+    }
+
+    private var storageURL: URL {
+        let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return documents.appendingPathComponent("places.json")
+    }
+}

--- a/ios/PlacesMemory/PlacesMemory/Views/AddPlaceView.swift
+++ b/ios/PlacesMemory/PlacesMemory/Views/AddPlaceView.swift
@@ -1,0 +1,89 @@
+import CoreLocation
+import SwiftUI
+
+struct AddPlaceView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var store: PlacesStore
+    @EnvironmentObject private var locationManager: LocationManager
+
+    @State private var title = ""
+    @State private var category: PlaceCategory = .other
+    @State private var note = ""
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Lugar") {
+                    TextField("Nombre breve", text: $title)
+                    Picker("Tipo", selection: $category) {
+                        ForEach(PlaceCategory.allCases) { category in
+                            Label(category.rawValue, systemImage: category.icon)
+                                .tag(category)
+                        }
+                    }
+                    TextField("Nota para recordarlo", text: $note, axis: .vertical)
+                        .lineLimit(3...6)
+                }
+
+                Section("Ubicación actual") {
+                    Button {
+                        locationManager.requestCurrentLocation()
+                    } label: {
+                        Label("Actualizar mi ubicación", systemImage: "location.fill")
+                    }
+
+                    if let location = locationManager.currentLocation {
+                        LabeledContent("Latitud", value: location.coordinate.latitude.formatted(.number.precision(.fractionLength(5))))
+                        LabeledContent("Longitud", value: location.coordinate.longitude.formatted(.number.precision(.fractionLength(5))))
+                    } else {
+                        Text("Pulsa el botón para capturar el punto donde estás ahora.")
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if let errorMessage = locationManager.errorMessage {
+                        Text(errorMessage)
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Nuevo lugar")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancelar") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Guardar") {
+                        savePlace()
+                    }
+                    .disabled(!canSave)
+                }
+            }
+            .onAppear {
+                locationManager.requestCurrentLocation()
+            }
+        }
+    }
+
+    private var canSave: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            !note.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+            locationManager.currentLocation != nil
+    }
+
+    private func savePlace() {
+        guard let location = locationManager.currentLocation else { return }
+
+        let place = Place(
+            title: title.trimmingCharacters(in: .whitespacesAndNewlines),
+            category: category,
+            note: note.trimmingCharacters(in: .whitespacesAndNewlines),
+            latitude: location.coordinate.latitude,
+            longitude: location.coordinate.longitude
+        )
+        store.add(place)
+        dismiss()
+    }
+}

--- a/ios/PlacesMemory/PlacesMemory/Views/PlaceDetailView.swift
+++ b/ios/PlacesMemory/PlacesMemory/Views/PlaceDetailView.swift
@@ -1,0 +1,57 @@
+import MapKit
+import SwiftUI
+
+struct PlaceDetailView: View {
+    let place: Place
+
+    @State private var position: MapCameraPosition
+
+    init(place: Place) {
+        self.place = place
+        _position = State(initialValue: .region(MKCoordinateRegion(
+            center: place.coordinate,
+            span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+        )))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                Map(position: $position) {
+                    Marker(place.title, systemImage: place.category.icon, coordinate: place.coordinate)
+                }
+                .frame(height: 260)
+                .clipShape(RoundedRectangle(cornerRadius: 18))
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Label(place.category.rawValue, systemImage: place.category.icon)
+                        .foregroundStyle(.blue)
+                    Text(place.note)
+                        .font(.body)
+                    Text(place.createdAt, format: .dateTime.day().month().year().hour().minute())
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Button {
+                    openInMaps()
+                } label: {
+                    Label("Abrir en Mapas", systemImage: "map.fill")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+            }
+            .padding()
+        }
+        .navigationTitle(place.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func openInMaps() {
+        let mapItem = MKMapItem(placemark: MKPlacemark(coordinate: place.coordinate))
+        mapItem.name = place.title
+        mapItem.openInMaps(launchOptions: [
+            MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeWalking
+        ])
+    }
+}

--- a/ios/PlacesMemory/PlacesMemory/Views/PlacesListView.swift
+++ b/ios/PlacesMemory/PlacesMemory/Views/PlacesListView.swift
@@ -1,0 +1,71 @@
+import MapKit
+import SwiftUI
+
+struct PlacesListView: View {
+    @EnvironmentObject private var store: PlacesStore
+    @State private var isAddingPlace = false
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if store.places.isEmpty {
+                    ContentUnavailableView(
+                        "Aún no tienes lugares",
+                        systemImage: "map",
+                        description: Text("Guarda una ubicación cuando pases por un sitio que quieras recordar.")
+                    )
+                } else {
+                    List {
+                        ForEach(store.places) { place in
+                            NavigationLink {
+                                PlaceDetailView(place: place)
+                            } label: {
+                                PlaceRow(place: place)
+                            }
+                        }
+                        .onDelete(perform: store.delete)
+                    }
+                }
+            }
+            .navigationTitle("Mis lugares")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        isAddingPlace = true
+                    } label: {
+                        Label("Guardar lugar", systemImage: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $isAddingPlace) {
+                AddPlaceView()
+            }
+        }
+    }
+}
+
+private struct PlaceRow: View {
+    let place: Place
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: place.category.icon)
+                .font(.title2)
+                .foregroundStyle(.blue)
+                .frame(width: 36)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(place.title)
+                    .font(.headline)
+                Text(place.note)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                Text(place.createdAt, format: .dateTime.day().month().year().hour().minute())
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/ios/PlacesMemory/project.yml
+++ b/ios/PlacesMemory/project.yml
@@ -1,0 +1,22 @@
+name: PlacesMemory
+options:
+  bundleIdPrefix: com.example
+  deploymentTarget:
+    iOS: "17.0"
+targets:
+  PlacesMemory:
+    type: application
+    platform: iOS
+    sources:
+      - PlacesMemory
+    info:
+      path: PlacesMemory/Info.plist
+      properties:
+        CFBundleDisplayName: PlacesMemory
+        UILaunchScreen: {}
+        NSLocationWhenInUseUsageDescription: "Usamos tu ubicación solo cuando guardas un lugar de interés cercano."
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.example.PlacesMemory
+        INFOPLIST_FILE: PlacesMemory/Info.plist
+        SWIFT_VERSION: 5.9


### PR DESCRIPTION
### Motivation
- Proveer una app móvil iOS para capturar y recordar lugares de interés guardando la ubicación actual y una nota asociada para consultarla más adelante.
- Tener una base mínima, local y offline que permita iterar sobre UI, permisos de ubicación y persistencia antes de añadir sincronización o multimedia.

### Description
- Añade el esqueleto del proyecto con `project.yml` para generar el proyecto Xcode y el punto de entrada `PlacesMemoryApp.swift` que inyecta los objetos de estado; ver `ios/PlacesMemory/project.yml` y `ios/PlacesMemory/PlacesMemory/PlacesMemoryApp.swift`.
- Implementa el modelo `Place` y las categorías en `ios/PlacesMemory/PlacesMemory/Models/Place.swift` para almacenar título, categoría, nota, coordenadas y fecha.
- Añade `LocationManager` en `ios/PlacesMemory/PlacesMemory/Services/LocationManager.swift` para solicitar permisos y capturar la ubicación actual con mensajes de error en español.
- Añade `PlacesStore` en `ios/PlacesMemory/PlacesMemory/Services/PlacesStore.swift` para persistencia local en JSON (`places.json`) y vistas SwiftUI `AddPlaceView`, `PlacesListView` y `PlaceDetailView` en `ios/PlacesMemory/PlacesMemory/Views/` para flujo de guardado, lista y detalle con mapa y apertura en Apple Maps.
- Incluye `Info.plist` con la clave `NSLocationWhenInUseUsageDescription` y actualiza el `README.md` con instrucciones para generar el proyecto y próximos pasos.

### Testing
- Ejecuté `plutil -lint ios/PlacesMemory/PlacesMemory/Info.plist` y el archivo `Info.plist` validó correctamente.
- Intenté `xcodegen generate` pero no se ejecutó porque `xcodegen` no está instalado en este entorno, por lo que no se generó el `.xcodeproj` aquí.
- Consulté `swift --version` en el entorno y `swift` está disponible, lo que verifica compatibilidad de desarrollo local, sin ejecutar pruebas de UI o simulador en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a193e5a5a208331b52625a8e02a08a1)